### PR TITLE
Bugfix for rollup plugin copyParentPlugin

### DIFF
--- a/src/rollup-plugin-nuxt-copy-from-parent.ts
+++ b/src/rollup-plugin-nuxt-copy-from-parent.ts
@@ -30,6 +30,7 @@ function copyParentPlugin(options: CopyParentPluginOptions): Plugin {
         initialized = true;  
         if (fs.existsSync(path.join(options.destinationDir, '.git'))) {
           console.log(yellow(`.git exists in ${options.destinationDir}. Copy from parent skipped.`));
+          return;
         }
   
         for (let what of items) {


### PR DESCRIPTION
Don't copy directory if the target directory contains git repository.