### PR TITLE
Addition of index parameter to the findByTag method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Gets the modified template.
 
 Before modifying elements you need to find proper element with simplified selectors.
 
-#### `findByTag(tagName: string)`
+#### `findByTag(tagName: string, tagNameIndex?: number)`
 
-Finds the first element with given tag
+Finds an element with a given tag and a zero-based index. Index is optional.
 
 #### `findByAttribute(name: string)`
 

--- a/src/VueElementFinder.ts
+++ b/src/VueElementFinder.ts
@@ -1,5 +1,6 @@
 type FindByOptions = {
   tagName?: string;
+  tagNameIndex?: number;
   attributeName?: string;
   attributeValue?: string;
 };
@@ -86,9 +87,13 @@ export abstract class VueElementFinder {
     if(!this.findByOptions?.tagName) {
       throw new Error('Invalid find options.');
     }
+    
     const tagName = this.findByOptions.tagName;
-    const regexp = new RegExp(`<${tagName}(?:\\s|\/?>)`);
-    const startIndexMatch = code.match(regexp);
+    const tagNameIndex = this.findByOptions.tagNameIndex ?? 0;
+    const regexp = new RegExp(`<${tagName}(?:\\s|\/?>)`, 'g');
+    const matchArray = Array.from(code.matchAll(regexp));
+    const startIndexMatch = matchArray[tagNameIndex];
+
     if (startIndexMatch?.index !== undefined) {
       const endIndexMatch = code.slice(startIndexMatch.index).match(/>/);
       if (endIndexMatch?.index !== undefined) {
@@ -97,6 +102,7 @@ export abstract class VueElementFinder {
         element = { startIndex, endIndex };
       }
     }
+    
     return element;
   }
 
@@ -141,9 +147,9 @@ export abstract class VueElementFinder {
     return this;
   }
 
-  public findByTag(tagName: string): VueElementFinder {
+  public findByTag(tagName: string, tagNameIndex: number = 0): VueElementFinder {
     this.findBy = 'tagName';
-    this.findByOptions = { tagName };
+    this.findByOptions = { tagName, tagNameIndex };
     return this;
   }
 

--- a/src/VueModifyTemplate.ts
+++ b/src/VueModifyTemplate.ts
@@ -8,8 +8,8 @@ export class VueModifyTemplate extends VueElementFinder {
     return this;
   }
 
-  public findByTag(tagName: string): VueModifyTemplate {
-    super.findByTag(tagName);
+  public findByTag(tagName: string, tagNameIndex: number = 0): VueModifyTemplate {
+    super.findByTag(tagName, tagNameIndex);
     return this;
   }
 

--- a/test/VueModifyTemplate.test.ts
+++ b/test/VueModifyTemplate.test.ts
@@ -26,10 +26,22 @@ describe('VueModifyTemplate', () => {
       const result = new VueModifyTemplate().fromTemplate(template).findByTag('div').getTemplate();
       expect(result).toEqual(template);
     });
+
+    it('finds a third element by tag name', () => {
+      const template = '<div class="foo"></div><div class="bar"></div><div class="baz"></div>';
+      const result = new VueModifyTemplate().fromTemplate(template).findByTag('div', 2).getTemplate();
+      expect(result).toEqual(template);
+    });
   
     it('finds an self closing component by tag name', () => {
       const template = '<div><comp/></div>';
       const result = new VueModifyTemplate().fromTemplate(template).findByTag('comp').getTemplate();
+      expect(result).toEqual(template);
+    });
+
+    it('finds a second self closing component by tag name', () => {
+      const template = '<div><comp/><comp/></div>';
+      const result = new VueModifyTemplate().fromTemplate(template).findByTag('comp', 1).getTemplate();
       expect(result).toEqual(template);
     });
 
@@ -39,12 +51,23 @@ describe('VueModifyTemplate', () => {
       const result = new VueModifyTemplate().fromTemplate(template).findByTag('div').extendAttribute('class', 'bar').getTemplate();
       expect(result).toEqual(expected);
     });
+
+    it('finds the fourth occurrence of an element by tag name', () => {
+      const template = '<div class="foo"><div class="foo"><div class="foo"><div class="foo"></div></div></div></div>';
+      const expected = '<div class="foo"><div class="foo"><div class="foo"><div class="bar"></div></div></div></div>';
+      const result = new VueModifyTemplate().fromTemplate(template).findByTag('div', 3).regexpAttribute('class', /foo/, 'bar').getTemplate();
+      expect(result).toEqual(expected);
+    });
   
     it('throws an error if no elements match the tag name', () => {
       const template = '<div class="foo"></div>';
       expect(() => new VueModifyTemplate().fromTemplate(template).findByTag('span').getTemplate()).toThrowError('Failed to find element in template.');
     });
-  
+
+    it('throws an error if no elements match the tag index', () => {
+      const template = '<div class="foo"><div class="bar"></div></div>';
+      expect(() => new VueModifyTemplate().fromTemplate(template).findByTag('div', 2).getTemplate()).toThrowError('Failed to find element in template.');
+    });
   });
 
   describe('findByAttribute', () => {


### PR DESCRIPTION
Adds ability to target any tag in the template by specifying element's index as a second argument in `findByTag(tagName: string, tagNameIndex?: number)` method.