### PR TITLE
Move generated comments out of template tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@creativestyle/kombinator",
-  "version": "3.1.7",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@creativestyle/kombinator",
-      "version": "3.1.7",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.20",
@@ -25,6 +25,7 @@
         "graphql": "^16.7.1",
         "jest": "^29.5.0",
         "rollup-plugin-copy": "^3.4.0",
+        "rollup-plugin-vue": "^6.0.0",
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.4",
         "vue": "^3.2.47"
@@ -2654,6 +2655,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/hash-sum": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+      "dev": true
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4321,6 +4328,35 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true
+    },
+    "node_modules/rollup-plugin-vue": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0.tgz",
+      "integrity": "sha512-oVvUd84d5u73M2HYM3XsMDLtZRIA/tw2U0dmHlXU2UWP5JARYHzh/U9vcxaN/x/9MrepY7VH3pHFeOhrWpxs/Q==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "hash-sum": "^2.0.0",
+        "rollup-pluginutils": "^2.8.2"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "*"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
       "dev": true
     },
     "node_modules/run-parallel": {
@@ -6916,6 +6952,12 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "hash-sum": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+      "dev": true
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -8138,6 +8180,34 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
           "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+          "dev": true
+        }
+      }
+    },
+    "rollup-plugin-vue": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0.tgz",
+      "integrity": "sha512-oVvUd84d5u73M2HYM3XsMDLtZRIA/tw2U0dmHlXU2UWP5JARYHzh/U9vcxaN/x/9MrepY7VH3pHFeOhrWpxs/Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "hash-sum": "^2.0.0",
+        "rollup-pluginutils": "^2.8.2"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "graphql": "^16.7.1",
     "jest": "^29.5.0",
     "rollup-plugin-copy": "^3.4.0",
+    "rollup-plugin-vue": "^6.0.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.4",
     "vue": "^3.2.47"

--- a/src/VueFileHandler.ts
+++ b/src/VueFileHandler.ts
@@ -75,6 +75,10 @@ export class VueFileHandler {
     return this.filePath ? fs.realpathSync(this.filePath) : null;
   }
 
+  getFileContent(): string | null {
+    return this.fileContent ? this.fileContent.trim() : null
+  }
+
   getTemplateAsString(): string {
     const templateMatch = this.fileContent?.match(/<template>([\s\S]*)<\/template>/);
     if (!templateMatch) {
@@ -92,11 +96,11 @@ export class VueFileHandler {
     if(!this.newFileContent) {
       throw new Error("Set new template first");
     }
-    const templateMatch = this.newFileContent?.match(/<template>([\s\S]*)<\/template>/);
+    const templateMatch = this.newFileContent?.match(/<template>[\s\S]*<\/template>(?:\s*<!-- Kombinator: [\s\S]*? -->)*\n?/);
     if (!templateMatch) {
       throw new Error(`No template found in ${this.filePath}`);
     }
-    const templateContent = templateMatch[1];
+    const templateContent = templateMatch[0];
     const newTemplateContent = templateContent + `<!-- Kombinator: ${comment} -->\n`;
     this.newFileContent = this.newFileContent.replace(templateContent, newTemplateContent);
     return this;

--- a/test/VueFileHandler.test.ts
+++ b/test/VueFileHandler.test.ts
@@ -27,17 +27,17 @@ describe('VueFileHandler', () => {
   it('should load a Vue file from a given location', () => {
     const vueFile = new VueFileHandler([generatedDir, coreDir]);
     vueFile.loadVueFile('subdirectory/my-component.vue');
-    const templateString = vueFile.getTemplateAsString();
+    const templateString = vueFile.getFileContent();
 
-    expect(templateString).toBe('<div>Hello world</div>');
+    expect(templateString).toBe('<template>\n<div>Hello world</div>\n</template>');
   });
 
   it('should find component by name', () => {
     const vueFile = new VueFileHandler([generatedDir, coreDir]);
     vueFile.loadComponent('my-component');
-    const templateString = vueFile.getTemplateAsString();
+    const templateString = vueFile.getFileContent();
 
-    expect(templateString).toBe('<div>Hello world</div>');
+    expect(templateString).toBe('<template>\n<div>Hello world</div>\n</template>');
   });
 
   it('should find component with dashes and TitleCased file', () => {    
@@ -47,9 +47,9 @@ describe('VueFileHandler', () => {
     fs.writeFileSync(filePath, fileContent, 'utf8');
     const vueFile = new VueFileHandler([generatedDir, coreDir]);
     vueFile.loadComponent('title-cased-component');
-    const templateString = vueFile.getTemplateAsString();
+    const templateString = vueFile.getFileContent();
 
-    expect(templateString).toBe('<div>Hello world</div>');
+    expect(templateString).toBe('<template>\n<div>Hello world</div>\n</template>');
   });
 
   it('should set a new template string', () => {
@@ -60,9 +60,9 @@ describe('VueFileHandler', () => {
     const vueFileOut = new VueFileHandler([generatedDir, coreDir]);
     vueFileOut.loadVueFile('subdirectory/my-component.vue');
     fs.unlinkSync(path.join(generatedDir, 'subdirectory/my-component.vue'));
-    const templateString = vueFileOut.getTemplateAsString();
+    const templateString = vueFileOut.getFileContent();
     
-    expect(templateString).toBe('<div>New template</div>');
+    expect(templateString).toBe('<template>\n<div>New template</div>\n</template>');
   });
 
   it('should add a comment to the template', () => {
@@ -73,9 +73,24 @@ describe('VueFileHandler', () => {
     vueFile.write();
     const vueFileOut = new VueFileHandler([generatedDir, coreDir]);
     vueFileOut.loadVueFile('subdirectory/my-component.vue');
-    const templateString = vueFileOut.getTemplateAsString();
+    const templateString = vueFileOut.getFileContent();
     fs.unlinkSync(path.join(generatedDir, 'subdirectory/my-component.vue'));
-    expect(templateString).toBe('<div>New template</div>\n<!-- Kombinator: This is a comment -->');
+    expect(templateString).toBe('<template>\n<div>New template</div>\n</template><!-- Kombinator: This is a comment -->');
+  });
+
+  it('should add multiple comments to the template, maintaining their order', () => {
+    const vueFile = new VueFileHandler([generatedDir, coreDir]);
+    vueFile.loadVueFile('subdirectory/my-component.vue');
+    vueFile.setNewTemplate('<div>New template</div>');
+    vueFile.addTemplateComment('This is a comment 1');
+    vueFile.addTemplateComment('This is a comment 2');
+    vueFile.addTemplateComment('This is a comment 3');
+    vueFile.write();
+    const vueFileOut = new VueFileHandler([generatedDir, coreDir]);
+    vueFileOut.loadVueFile('subdirectory/my-component.vue');
+    const templateString = vueFileOut.getFileContent();
+    fs.unlinkSync(path.join(generatedDir, 'subdirectory/my-component.vue'));
+    expect(templateString).toBe('<template>\n<div>New template</div>\n</template><!-- Kombinator: This is a comment 1 -->\n<!-- Kombinator: This is a comment 2 -->\n<!-- Kombinator: This is a comment 3 -->');
   });
 
   it('should write the updated file to a new location / name', () => {

--- a/test/vite-plugin-execute-mods.test.ts
+++ b/test/vite-plugin-execute-mods.test.ts
@@ -1,0 +1,161 @@
+import fse from 'fs-extra';
+import path from 'path';
+import temp from 'temp';
+import { rollup, type Plugin } from 'rollup';
+import modsPlugin, { type ModsPluginOptions } from '../src/vite-plugin-execute-mods';
+import vuePlugin from 'rollup-plugin-vue'
+import { trimMultilineString } from './helpers';
+
+temp.track(); // Automatically track and clean up files at exit
+
+describe('vite-plugin-execute-mods', () => {
+  let tempDir: string;
+  let sourceDir: string;
+  let sourceFilePath: string;
+  let modsDir: string;
+  let destinationDir: string;
+  let localComponentsDir: string;
+  let options: ModsPluginOptions;
+  let plugin: Plugin;
+
+  beforeEach(() => {
+    initializeDirsStructure()
+
+    options = {
+      modsDir: modsDir,
+      localComponentsDir: localComponentsDir,
+      componentsDir: [destinationDir, sourceDir],
+      verbose: false,
+      tags: ['script', 'template', 'style']
+    };
+    plugin = modsPlugin(options);
+  });
+
+  afterEach(() => {
+    // Remove the temporary directory after each test
+    temp.cleanupSync();
+  });
+
+  describe('template mods', () => {
+    it('should modify vue SFC template', async () => {
+      // add template mod files
+      const mod1FilePath = path.join(modsDir, 'HelloWorld1.mod.ts')
+      fse.writeFileSync(mod1FilePath, getTestModContent('First mod'));
+      const mod2FilePath = path.join(modsDir, 'HelloWorld2.mod.ts')
+      fse.writeFileSync(mod2FilePath, getTestModContent('Second mod'));
+
+      function getTestModContent(text: string) {
+        return `
+        module.exports = function (withComponent: any) {
+          const t = withComponent('HelloWorld')
+          t.templateModificator
+            .findByTag('div')
+            .insertAfter('<span>${text}</span>')
+          t.saveModifiedTemplate()
+        }`
+      };
+
+      const outputFileContent = await getRollupOutput()
+  
+      const expectedFileContent = trimMultilineString(`
+        <template>
+          <div>Hello, World!</div><span>Second mod</span><span>First mod</span>
+        </template>
+        <!-- Kombinator: HelloWorld1.mod.ts:7:13 -->
+        <!-- Kombinator: HelloWorld2.mod.ts:7:13 -->
+        
+        <script setup>
+        console.log("Hello");
+        </script>
+      `).trim();
+  
+      expect(outputFileContent).toBe(expectedFileContent)
+    });
+  })
+
+  describe('vue mods', () => {
+    it('should extend existing script', async () => {
+      // add vue script mod
+      const modFilePath = path.join(localComponentsDir, 'HelloWorld.mod.vue')
+      fse.writeFileSync(modFilePath, `<script setup>\nconsole.log("Appended by mod");\n</script>`);
+
+      const outputFileContent = await getRollupOutput()
+      
+      const expectedFileContent = trimMultilineString(`
+        <template>
+          <div>Hello, World!</div>
+        </template>
+        <!-- Kombinator: Applied vue mod ${modFilePath} -->
+        
+        <script setup>
+        console.log("Hello");
+
+
+        console.log("Appended by mod");
+        </script>
+      `).trim();
+
+      expect(outputFileContent).toBe(expectedFileContent)
+    })
+
+    it('should replace existing script with kombinator="replace"', async () => {
+      // add vue script mod
+      const modFilePath = path.join(localComponentsDir, 'HelloWorld.mod.vue')
+      fse.writeFileSync(modFilePath, `<script setup kombinator="replace">\nconsole.log("Replaced by mod");\n</script>`);
+
+      const outputFileContent = await getRollupOutput()
+      
+      const expectedFileContent = trimMultilineString(`
+        <template>
+          <div>Hello, World!</div>
+        </template>
+        <!-- Kombinator: Applied vue mod ${modFilePath} -->
+        
+        <script setup>
+        console.log("Replaced by mod");
+        </script>
+      `).trim();
+
+      expect(outputFileContent).toBe(expectedFileContent)
+    })
+  })
+
+  async function getRollupOutput() {
+    await rollup({
+      input: sourceFilePath,
+      plugins: [
+        vuePlugin(),
+        plugin
+      ],
+      external: ['vue']
+    });
+
+    const outputFilePath = path.join(destinationDir, 'HelloWorld.vue')
+    const outputFileContent = fse.readFileSync(outputFilePath, 'utf-8').trim()
+    return outputFileContent
+  }
+
+  function initializeDirsStructure() {
+    // Create a temporary directory for testing
+    tempDir = temp.mkdirSync('tempDir');
+
+    // Create a test source Vue SFC file: tempDir/core/components/HelloWorld.vue
+    sourceDir = path.join(tempDir, 'core', 'components');
+    fse.mkdirSync(sourceDir, { recursive: true });
+    sourceFilePath = path.join(sourceDir, 'HelloWorld.vue');
+    const sourceFileContent = '<template>\n<div>Hello, World!</div>\n</template>\n\n<script setup>\nconsole.log("Hello");\n</script>\n';
+    fse.writeFileSync(sourceFilePath, sourceFileContent, 'utf8');
+
+    // Create a directory with template mods: tempDir/mods
+    modsDir = path.join(tempDir, 'mods');
+    fse.mkdirSync(modsDir);
+
+    // Create destination directory: tempDir/.kombinator/components
+    destinationDir = path.join(tempDir, '.kombinator', 'components');
+    fse.mkdirSync(destinationDir, { recursive: true });
+
+    // Create local components directory: tempDir/components
+    localComponentsDir = path.join(tempDir, 'components');
+    fse.mkdirSync(localComponentsDir);
+  }
+});


### PR DESCRIPTION
Currently kombinator inserts comments (informing developers what mods were applies) inside `<template>` tags of vue components. This change moves the generated comments below `<template>` tag.

Comments inside `<template>` tags make modified components have multiple root components. It may potentially cause issues. In Nuxt docs we can read:

> Pages must have a single root element to allow [route transitions](https://nuxt.com/docs/getting-started/transitions) between pages, HTML comments are considered elements as well.

:arrow_up: [source](https://nuxt.com/docs/guide/directory-structure/pages#usage)

> Unlike other components, your layouts must have a single root element to allow Nuxt to apply transitions between layout changes - and this root element cannot be a `<slot />`.

:arrow_up: [source](https://nuxt.com/docs/guide/directory-structure/layouts#enable-layouts)

From vue docs:

> `<Transition>` only supports a single element or component as its slot content. If the content is a component, the component must also have only one single root element.

:arrow_up: [source](https://vuejs.org/guide/built-ins/transition#the-transition-component)