### PR TITLE
fix: Fix exports in VueFileHandler and GraphqlFileHandler

### DIFF
--- a/src/VueFileHandler.ts
+++ b/src/VueFileHandler.ts
@@ -125,5 +125,3 @@ export class VueFileHandler {
     fs.writeFileSync(newFile, newFileContent!);
   }
 }
-
-export default VueFileHandler;

--- a/src/graphql/GraphqlFileHandler.ts
+++ b/src/graphql/GraphqlFileHandler.ts
@@ -112,5 +112,3 @@ export class GraphqlFileHandler {
     fs.writeFileSync(newFile, newFileContent!);
   }
 }
-
-export default GraphqlFileHandler;

--- a/test/VueFileHandler.test.ts
+++ b/test/VueFileHandler.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import temp from 'temp';
-import VueFileHandler from '../src/VueFileHandler';
+import { VueFileHandler } from '../src/VueFileHandler';
 
 temp.track(); // Automatically track and clean up files at exit
 

--- a/test/graphql/GraphqlFileHandler.test.ts
+++ b/test/graphql/GraphqlFileHandler.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import temp from 'temp';
-import GraphqlFileHandler from '../../src/graphql/GraphqlFileHandler';
+import { GraphqlFileHandler } from '../../src/graphql/GraphqlFileHandler';
 
 temp.track(); // Automatically track and clean up files at exit
 


### PR DESCRIPTION
Fixes the problem with loading Kombinator plugins after latest release of jiti (https://github.com/unjs/jiti/releases/tag/v1.21.1).

```
[error] [mods-plugin] _VueFileHandler.VueFileHandler is not a constructor
[error] Nuxt Build Error: _VueFileHandler.VueFileHandler is not a constructor
  at node_modules/@creativestyle/kombinator/dist/vite-plugin-execute-mods.js:88:29
  at Array.forEach (<anonymous>)
  at processVueMods (node_modules/@creativestyle/kombinator/dist/vite-plugin-execute-mods.js:73:11)
  at Object.handler (node_modules/@creativestyle/kombinator/dist/vite-plugin-execute-mods.js:106:11)
  at node_modules/@nuxt/vite-builder/node_modules/rollup/dist/es/shared/node-entry.js:19774:40
  at async Promise.all (index 0)
  at async PluginDriver.hookParallel (node_modules/@nuxt/vite-builder/node_modules/rollup/dist/es/shared/node-entry.js:19702:9)
  at async node_modules/@nuxt/vite-builder/node_modules/rollup/dist/es/shared/node-entry.js:20609:13
  at async catchUnfinishedHookActions (node_modules/@nuxt/vite-builder/node_modules/rollup/dist/es/shared/node-entry.js:20119:16)
  at async rollupInternal (node_modules/@nuxt/vite-builder/node_modules/rollup/dist/es/shared/node-entry.js:20606:5)
  at async Module.build (node_modules/@nuxt/vite-builder/node_modules/vite/dist/node/chunks/dep-V3BH7oO1.js:67172:18)
  at async buildClient (node_modules/@nuxt/vite-builder/dist/shared/vite-builder.NwMCGWpb.mjs:569:5)
  at async bundle (node_modules/@nuxt/vite-builder/dist/shared/vite-builder.NwMCGWpb.mjs:1462:3)
  at async bundle (node_modules/nuxt/dist/index.mjs:4729:5)
  at async Promise.all (index 1)
  at async build (node_modules/nuxt/dist/index.mjs:4604:5)
  at async Object.run (node_modules/nuxi/dist/chunks/build.mjs:95:5)
  at async runCommand$1 (node_modules/nuxi/dist/shared/nuxi.9edf0930.mjs:1648:16)
  at async runCommand$1 (node_modules/nuxi/dist/shared/nuxi.9edf0930.mjs:1639:11)
  at async runMain$1 (node_modules/nuxi/dist/shared/nuxi.9edf0930.mjs:1777:7)
``` 